### PR TITLE
fix unexpected markets candle field name symbol changes

### DIFF
--- a/src/schema/candles.rs
+++ b/src/schema/candles.rs
@@ -31,6 +31,7 @@ impl Default for Candle {
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct CandlesResponse {
+    #[serde(rename = "symbol")]
     pub symbol_id: String,
     #[serde(rename = "type")]
     pub typ: String,

--- a/tests/testdata/candles_response.json
+++ b/tests/testdata/candles_response.json
@@ -1,5 +1,5 @@
 {
-    "symbolId": "2884",
+    "symbol": "2884",
     "type": "EQUITY",
     "exchange": "TWSE",
     "market": "TSE",


### PR DESCRIPTION
the official docs remain using symbolId as the response name
https://developer.fugle.tw/docs/data/marketdata/candles
but the actual API changed the naming.